### PR TITLE
Fixed require statement for archive mode.

### DIFF
--- a/org-krita.el
+++ b/org-krita.el
@@ -29,7 +29,7 @@
 
 ;;; Code:
 
-(require 'archive-mode)
+(require 'arc-mode)
 (require 'filenotify)
 (require 'f)
 (require 'cl-lib)


### PR DESCRIPTION
Hi lepisma,

As mentioned in this issue, the require statement for archive mode in Emacs is wrong. It should be `(require 'arc-mode)`.
https://github.com/lepisma/org-krita/issues/1#issuecomment-653279712

This is causing an error that 'archive-mode is not enabled' whenever someone tries to enable `org-krita-mode`.

Please accept this pull request.