### PR TITLE
Support tilde expansion ("~") in file paths.

### DIFF
--- a/org-krita.el
+++ b/org-krita.el
@@ -65,7 +65,7 @@
   "Extract png from given KRA-PATH and return data."
   (with-temp-buffer
     (set-buffer-multibyte nil)
-    (archive-zip-extract kra-path "mergedimage.png")
+    (archive-zip-extract (expand-file-name kra-path) "mergedimage.png")
     (buffer-string)))
 
 (defun org-krita-get-links ()


### PR DESCRIPTION
Without this patch, org-krita supports absolute and relative
filepaths, but the unzip process doesn't successfully support the
tilde in a test Debian Buster system.

Fortunately, we can expand the tilde before giving it to unzipper to
prevent any filepath issues.

Now, the following three links all display in the org-mode buffer and
are all equivalent:

- [[krita:krita-test.kra][krita-test]]
- [[krita:/home/test/krita-test.kra][krita-test]]
- [[krita:~/krita-test.kra][krita-test]]