### PR TITLE
switch to custom-link solution

### DIFF
--- a/README.org
+++ b/README.org
@@ -22,7 +22,7 @@ do the following:
 #+begin_src emacs-lisp
   (use-package org-krita
     :ensure t
-    :quelpa (org-krita :fetcher github :repo "lepisma/org-krita" :files ("*.el" "resources"))
+    :quelpa (org-krita :fetcher github :repo "hermanhel/org-krita" :files ("*.el" "resources"))
     :config
     (add-hook 'org-mode-hook 'org-krita-mode))
 #+end_src
@@ -31,32 +31,13 @@ Or, if you are using Doom emacs you can add this to your =packages.el=:
 #+begin_src emacs-lisp
 (package! org-krita
   :recipe (:host github
-           :repo "lepisma/org-krita"
+           :repo "hermanhel/org-krita"
            :files ("resources" "resources" "*.el" "*.el")))
-#+end_src
-
-and this to your =config.el=:
-#+begin_src emacs-lisp
-(use-package! org-krita
-  :config
-  (add-hook 'org-mode-hook 'org-krita-mode))
 #+end_src
 
 =org-krita= creates a new org link type called =krita= that:
 - when clicked on, opens krita for editing the file linked, and
-- shows the updated image preview inline if =org-krita-mode= is enabled.
+- shows the updated image preview inline if call =org-display-inline-images=
 
-For using, you need to enable the minor mode =org-krita-mode= in org buffer with
-=krita= links like this =[[krita:./some-file.kra][image]]=. To create new files
+To create new files
 within the buffer itself, try calling =org-krita-insert-new-image=.
-
-** Roadmap
-Here are the directions that need work (as far as I can think of right now):
-1. Making the package tool agnostic. This basically means abstracting out the
-   following pieces that are tuned to krita at the moment:
-   1. Function for creating new image in the tool's format.
-   2. Function for extracting =png= from the file for inline display.
-   3. Function for running the program to edit an image.
-2. Better inline display. Right now we bypass org's inline display which means
-   we miss out on basic things like setting width and height for larger images
-   and other goodies.

--- a/README.org
+++ b/README.org
@@ -1,5 +1,13 @@
 #+TITLE: org-krita
 
+# fork of lepisma's org-krita package
+used `:image-data-fun` attribute of org-link-parameter instead of "bypassing org-mode's image display. This approach is used also by github.com/wdavew/org-excalidraw
+
+This way:
++ krita links' image display goes with org-inline-image-display
++ in the bypassing version of org-krita you can always see a blue line in the middle of image, which is gone when you have your cursor on it which I think is the underline under link. It is gone now.
++ set width with `#+attr_html: :width 100`
+
 [[tag][file:https://img.shields.io/github/v/tag/lepisma/org-krita.svg]]
 
 Minor mode for working with [[https://krita.org/en/][krita]] notes, sketches etc. in org mode.

--- a/README.org
+++ b/README.org
@@ -1,6 +1,6 @@
 #+TITLE: org-krita
 
-# fork of lepisma's org-krita package
+** fork of lepisma's org-krita package
 used `:image-data-fun` attribute of org-link-parameter instead of "bypassing org-mode's image display. This approach is used also by github.com/wdavew/org-excalidraw
 
 This way:

--- a/org-krita.el
+++ b/org-krita.el
@@ -35,7 +35,14 @@
 (require 'cl-lib)
 (require 'org)
 
-(org-link-set-parameters "krita" :follow #'org-krita-edit :export #'org-krita-export)
+(defun org-krita-image-data-fun (_protocol link _desc)
+                                           (with-temp-buffer 
+                                              (set-buffer-multibyte nil)
+                                              (archive-zip-extract (expand-file-name link) "mergedimage.png")
+                                              (buffer-string)
+                                              ))
+
+(org-link-set-parameters "krita" :follow #'org-krita-edit :export #'org-krita-export :image-data-fun #'org-krita-image-data-fun)
 
 ;; NOTE: Only single reference for a file supported as of now.
 
@@ -201,10 +208,10 @@ If FULL-MODE is not null, run full krita."
   (org-krita-enable))
 
 ;;;###autoload
-(define-minor-mode org-krita-mode
-  "Mode for displaying editable krita images within Org file."
-  :init-value nil
-  (if org-krita-mode (org-krita-enable) (org-krita-disable)))
+;;(define-minor-mode org-krita-mode
+;;  "Mode for displaying editable krita images within Org file."
+;;  :init-value nil
+;;  (if org-krita-mode (org-krita-enable) (org-krita-disable)))
 
 (provide 'org-krita)
 


### PR DESCRIPTION
used `:image-data-fun` attribute of `org-link-set-parameters`.

This way krita links images are displayed as custom link, and can intergrate with org-mode's inline image display.